### PR TITLE
Make shadow autorun tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /node_modules/
 /resources/public/tailwind.css
 /resources/public/js/
+/resources/test/tests.js

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:paths ["src" "resources"]
+{:paths ["src" "resources" "test"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
         datascript/datascript {:mvn/version "1.7.3"}
         no.cjohansen/phosphor-clj {:mvn/version "2025.03.14"}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -4,4 +4,9 @@
  {:app
   {:target :browser
    :modules {:main {:init-fn toil.dev/main}}
-   :dev {:output-dir "resources/public/js"}}}}
+   :dev {:output-dir "resources/public/js"}}
+  :test
+  {:target    :node-test
+   :output-to "resources/test/tests.js"
+   :ns-regexp "-test$"
+   :autorun   true}}}


### PR DESCRIPTION
Adding shadow config for auto-running tests. Had to also add `"test"` to the classpath.

Some of the tests error out:

```
========= Running Tests =======================

Testing toil.forms-test
[:app] Build completed. (162 files, 0 compiled, 0 warnings, 1.49s)

ERROR in (submit-form-test) (toil/forms_test.cljc:97:9)
Calls form handle when form is valid
expected: (= (forms/submit {:form/id :forms/test-form, :form/handler (fn [data task-id] [[:db/transact [(assoc data :db/id task-id)]]])} {:task/name "Do it!"} 1) [[:db/transact [{:db/id 1, :task/name "Do it!"} [:db/retractEntity [:form/id :forms/test-form]]]]])
  actual: #object[Error Error: Invalid arity: 2]

ERROR in (submit-form-test) (toil/forms_test.cljc:108:9)
Cleans up form even when it doesn't do a db/transact
expected: (= (forms/submit {:form/id :forms/test-form, :form/handler (fn [data task-id] [])} {:task/name "Do it!"} 1) [[:db/transact [[:db/retractEntity [:form/id :forms/test-form]]]]])
  actual: #object[Error Error: Invalid arity: 2]

Ran 2 tests containing 10 assertions.
0 failures, 2 errors.
```

I haven't investigated what that is about.